### PR TITLE
Suggested changes

### DIFF
--- a/tests/bundles/bionic-stable.yaml
+++ b/tests/bundles/bionic-stable.yaml
@@ -7,6 +7,14 @@ applications:
       monitor-count: 1
     to:
       - "0"
+  # Skipping placement; placement not compatible with bionic/stein
+  prometheus-openstack-exporter:
+    charm: cs:prometheus-openstack-exporter
+    num_units: 1
+    options:
+      snap_channel: stable
+    to:
+      - "0"
   ceph-osd:
     charm: cs:ceph-osd
     num_units: 3
@@ -23,23 +31,25 @@ applications:
     num_units: 1
     to:
       - "1"
-  elastic:
-    charm: cs:elasticsearch
-    num_units: 1
-    options:
-      es-heap-size: 1
-    to:
-      - "15"
-  filebeat:
-    charm: cs:filebeat
-  grafana:
-    charm: cs:grafana
+  neutron-api:
+    charm: cs:neutron-api
     num_units: 1
     to:
-      - "5"
+      - "1"
     options:
-      install_method: snap
-      snap_channel: 21.04/stable
+      manage-neutron-plugin-legacy-mode: True
+      flat-network-providers: physnet1
+      neutron-security-groups: true
+  nova-compute:
+    charm: cs:nova-compute
+    num_units: 1
+    to:
+      - "2"
+  glance:
+    charm: cs:glance
+    num_units: 1
+    to:
+      - "3"
   graylog:
     charm: cs:graylog
     num_units: 1
@@ -47,18 +57,6 @@ applications:
       channel: 2/stable
     to:
       - "4"
-  hw-health:
-    charm: cs:hw-health
-  keystone:
-    charm: cs:keystone
-    num_units: 1
-    to:
-      - "6"
-  mongo:
-    charm: cs:mongodb
-    num_units: 1
-    to:
-      - "14"
   mysql:
     charm: cs:percona-cluster
     num_units: 1
@@ -71,28 +69,14 @@ applications:
       - "8"
     options:
       enable_livestatus: true
-  thruk-agent:
-    charm: cs:thruk-agent
-    num_units: 0
-  nrpe:
-    charm: cs:nrpe
+  openstack-service-checks:
+    charm: cs:openstack-service-checks
+    num_units: 1
     options:
-      swap: ''
-  nova-cloud-controller:
-    charm: cs:nova-cloud-controller
-    num_units: 1
+      check-neutron-agents: False
+      check-octavia: False
     to:
-      - "9"
-  cinder:
-    charm: cs:cinder
-    num_units: 1
-    to:
-      - "10"
-  rabbitmq-server:
-    charm: cs:rabbitmq-server
-    num_units: 1
-    to:
-      - "11"
+      - "12"
   prometheus:
     charm: cs:prometheus2
     num_units: 1
@@ -108,45 +92,47 @@ applications:
     num_units: 1
     to:
       - "13"
-  prometheus-openstack-exporter:
-    charm: cs:prometheus-openstack-exporter
+  elastic:
+    charm: cs:elasticsearch
     num_units: 1
     options:
-      snap_channel: stable
-    to:
-      - "0"
-  openstack-service-checks:
-    charm: cs:openstack-service-checks
+      es-heap-size: 1
+  filebeat:
+    charm: cs:filebeat
+  grafana:
+    charm: cs:grafana
     num_units: 1
     options:
-      check-neutron-agents: False
-      check-octavia: False
-    to:
-      - "12"
+      install_method: snap
+      snap_channel: 21.04/stable
+  hw-health:
+    charm: cs:hw-health
+  keystone:
+    charm: cs:keystone
+    num_units: 1
+  mongo:
+    charm: cs:mongodb
+    num_units: 1
+  thruk-agent:
+    charm: cs:thruk-agent
+    num_units: 0
+  nrpe:
+    charm: cs:nrpe
+    options:
+      swap: ''
+  nova-cloud-controller:
+    charm: cs:nova-cloud-controller
+    num_units: 1
+  cinder:
+    charm: cs:cinder
+    num_units: 1
+  rabbitmq-server:
+    charm: cs:rabbitmq-server
+    num_units: 1
   sysconfig:
     charm: cs:sysconfig
   telegraf:
     charm: cs:telegraf-41
-  nova-compute:
-    charm: cs:nova-compute
-    num_units: 1
-    to:
-      - "2"
-  glance:
-    charm: cs:glance
-    num_units: 1
-    to:
-      - "3"
-  neutron-api:
-    charm: cs:neutron-api
-    num_units: 1
-    to:
-      - "1"
-    options:
-      manage-neutron-plugin-legacy-mode: True
-      flat-network-providers: physnet1
-      neutron-security-groups: true
-  # Skipping placement; placement not compatible with bionic/stein
   neutron-openvswitch:
     charm: cs:neutron-openvswitch
     num_units: 0
@@ -163,17 +149,10 @@ machines:
   "3": {}
   "4":
     mem: 3G
-  "5": {}
-  "6": {}
-  "7": {} 
+  "7": {}
   "8": {}
-  "9": {}
-  "10": {}
-  "11": {}
   "12": {}
   "13": {}
-  "14": {}
-  "15": {}
 relations:
 - - prometheus-openstack-exporter:nrpe-external-master
   - nrpe:nrpe-external-master

--- a/tests/bundles/bionic-stable.yaml
+++ b/tests/bundles/bionic-stable.yaml
@@ -92,6 +92,12 @@ applications:
     num_units: 1
     to:
       - "8"
+  canonical-livepatch:
+    charm: cs:canonical-livepatch
+    num_units: 0
+  cinder:
+    charm: cs:cinder
+    num_units: 1
   elastic:
     charm: cs:elasticsearch
     num_units: 1
@@ -113,8 +119,8 @@ applications:
   mongo:
     charm: cs:mongodb
     num_units: 1
-  thruk-agent:
-    charm: cs:thruk-agent
+  neutron-openvswitch:
+    charm: cs:neutron-openvswitch
     num_units: 0
   nrpe:
     charm: cs:nrpe
@@ -123,9 +129,9 @@ applications:
   nova-cloud-controller:
     charm: cs:nova-cloud-controller
     num_units: 1
-  cinder:
-    charm: cs:cinder
-    num_units: 1
+  prometheus-libvirt-exporter:
+    charm: cs:prometheus-libvirt-exporter
+    num_units: 0
   rabbitmq-server:
     charm: cs:rabbitmq-server
     num_units: 1
@@ -133,14 +139,8 @@ applications:
     charm: cs:sysconfig
   telegraf:
     charm: cs:telegraf-41
-  neutron-openvswitch:
-    charm: cs:neutron-openvswitch
-    num_units: 0
-  prometheus-libvirt-exporter:
-    charm: cs:prometheus-libvirt-exporter
-    num_units: 0
-  canonical-livepatch:
-    charm: cs:canonical-livepatch
+  thruk-agent:
+    charm: cs:thruk-agent
     num_units: 0
 machines:
   "0": {}

--- a/tests/bundles/bionic-stable.yaml
+++ b/tests/bundles/bionic-stable.yaml
@@ -61,12 +61,12 @@ applications:
     charm: cs:percona-cluster
     num_units: 1
     to:
-      - "7"
+      - "5"
   nagios:
     charm: cs:nagios
     num_units: 1
     to:
-      - "8"
+      - "6"
     options:
       enable_livestatus: true
   openstack-service-checks:
@@ -76,22 +76,22 @@ applications:
       check-neutron-agents: False
       check-octavia: False
     to:
-      - "12"
+      - "7"
   prometheus:
     charm: cs:prometheus2
     num_units: 1
     to:
-      - "12"
+      - "7"
   prometheus-alertmanager:
     charm: cs:prometheus-alertmanager
     num_units: 1
     to:
-      - "13"
+      - "8"
   prometheus-ceph-exporter:
     charm: cs:prometheus-ceph-exporter
     num_units: 1
     to:
-      - "13"
+      - "8"
   elastic:
     charm: cs:elasticsearch
     num_units: 1
@@ -149,10 +149,10 @@ machines:
   "3": {}
   "4":
     mem: 3G
+  "5": {}
+  "6": {}
   "7": {}
   "8": {}
-  "12": {}
-  "13": {}
 relations:
 - - prometheus-openstack-exporter:nrpe-external-master
   - nrpe:nrpe-external-master

--- a/tests/bundles/bionic-stable.yaml
+++ b/tests/bundles/bionic-stable.yaml
@@ -67,10 +67,10 @@ applications:
   nagios:
     charm: cs:nagios
     num_units: 1
-    options:
-      enable_livestatus: true
     to:
       - "8"
+    options:
+      enable_livestatus: true
   thruk-agent:
     charm: cs:thruk-agent
     num_units: 0
@@ -142,6 +142,14 @@ applications:
     num_units: 1
     to:
       - "1"
+    options:
+      manage-neutron-plugin-legacy-mode: True
+      flat-network-providers: physnet1
+      neutron-security-groups: true
+  # Skipping placement; placement not compatible with bionic/stein
+  neutron-openvswitch:
+    charm: cs:neutron-openvswitch
+    num_units: 0
   prometheus-libvirt-exporter:
     charm: cs:prometheus-libvirt-exporter
     num_units: 0
@@ -153,7 +161,8 @@ machines:
   "1": {}
   "2": {}
   "3": {}
-  "4": {}
+  "4":
+    mem: 3G
   "5": {}
   "6": {}
   "7": {} 
@@ -267,6 +276,13 @@ relations:
   - glance:image-service
 - - grafana:dashboards
   - telegraf:dashboards
+- - neutron-openvswitch:neutron-plugin-api
+  - neutron-api:neutron-plugin-api
+- - nova-compute:neutron-plugin
+  - neutron-openvswitch:neutron-plugin
+- - neutron-openvswitch:amqp
+  - rabbitmq-server:amqp
+# Skipping placement relations; placement not compatible with xenial/queens
 - - nova-compute:juju-info
   - prometheus-libvirt-exporter:juju-info
 - - prometheus:target
@@ -279,4 +295,3 @@ relations:
   - nrpe:nrpe-external-master
 - - graylog:nrpe-external-master
   - nrpe:nrpe-external-master
-

--- a/tests/bundles/focal-stable.yaml
+++ b/tests/bundles/focal-stable.yaml
@@ -18,6 +18,11 @@ applications:
       - "1"
       - "2"
       - "3"
+  easyrsa:
+    charm: cs:~containers/easyrsa
+    num_units: 1
+    to:
+      - "1"
   elastic:
     charm: cs:elasticsearch
     num_units: 1
@@ -68,6 +73,10 @@ applications:
       - "8"
     options:
       enable_livestatus: true
+  thruk-agent:
+    charm: cs:thruk-agent
+    num_units: 0
+    series: bionic
   nrpe:
     charm: cs:nrpe
     options:
@@ -203,6 +212,8 @@ relations:
   - mongo:database
 - - graylog:elasticsearch
   - elastic:client
+- - easyrsa:client
+  - graylog:certificates
 - - sysconfig:juju-info
   - mysql:juju-info
 - - openstack-service-checks:juju-info
@@ -292,8 +303,9 @@ relations:
   - prometheus-libvirt-exporter:scrape
 - - canonical-livepatch:juju-info
   - ceph-osd:juju-info
+- - thruk-agent:general-info
+  - nagios:juju-info
 - - grafana:nrpe-external-master
   - nrpe:nrpe-external-master
 - - graylog:nrpe-external-master
   - nrpe:nrpe-external-master
-

--- a/tests/bundles/focal-stable.yaml
+++ b/tests/bundles/focal-stable.yaml
@@ -66,13 +66,13 @@ applications:
     num_units: 1
     series: bionic
     to:
-      - "7"
+      - "5"
   nagios:
     charm: cs:nagios
     num_units: 1
     series: bionic
     to:
-      - "8"
+      - "6"
     options:
       enable_livestatus: true
   openstack-service-checks:
@@ -82,22 +82,22 @@ applications:
       check-neutron-agents: False
       check-octavia: False
     to:
-      - "12"
+      - "7"
   prometheus:
     charm: cs:prometheus2
     num_units: 1
     to:
-      - "12"
+      - "7"
   prometheus-alertmanager:
     charm: cs:prometheus-alertmanager
     num_units: 1
     to:
-      - "13"
+      - "8"
   prometheus-ceph-exporter:
     charm: cs:prometheus-ceph-exporter
     num_units: 1
     to:
-      - "13"
+      - "8"
   elastic:
     charm: cs:elasticsearch
     num_units: 1
@@ -156,12 +156,12 @@ machines:
   "3": {}
   "4":
     mem: 3G
-  "7":
+  "5":
     series: bionic
-  "8":
+  "6":
     series: bionic
-  "12": {}
-  "13": {}
+  "7": {}
+  "8": {}
 relations:
 - - prometheus-openstack-exporter:nrpe-external-master
   - nrpe:nrpe-external-master

--- a/tests/bundles/focal-stable.yaml
+++ b/tests/bundles/focal-stable.yaml
@@ -7,6 +7,18 @@ applications:
       monitor-count: 1
     to:
       - "0"
+  placement:
+    charm: cs:placement
+    num_units: 1
+    to:
+      - "0"
+  prometheus-openstack-exporter:
+    charm: cs:prometheus-openstack-exporter
+    num_units: 1
+    options:
+      snap_channel: stable
+    to:
+      - "0"
   ceph-osd:
     charm: cs:ceph-osd
     num_units: 3
@@ -23,23 +35,25 @@ applications:
     num_units: 1
     to:
       - "1"
-  elastic:
-    charm: cs:elasticsearch
-    num_units: 1
-    options:
-      es-heap-size: 1
-    to:
-      - "15"
-  filebeat:
-    charm: cs:filebeat
-  grafana:
-    charm: cs:grafana
+  neutron-api:
+    charm: cs:neutron-api
     num_units: 1
     to:
-      - "5"
+      - "1"
     options:
-      install_method: snap
-      snap_channel: 21.04/stable
+      manage-neutron-plugin-legacy-mode: True
+      flat-network-providers: physnet1
+      neutron-security-groups: true
+  nova-compute:
+    charm: cs:nova-compute
+    num_units: 1
+    to:
+      - "2"
+  glance:
+    charm: cs:glance
+    num_units: 1
+    to:
+      - "3"
   graylog:
     charm: cs:graylog
     num_units: 1
@@ -47,18 +61,6 @@ applications:
       channel: 2/stable
     to:
       - "4"
-  hw-health:
-    charm: cs:hw-health
-  keystone:
-    charm: cs:keystone
-    num_units: 1
-    to:
-      - "6"
-  mongo:
-    charm: cs:mongodb
-    num_units: 1
-    to:
-      - "14"
   mysql:
     charm: cs:percona-cluster
     num_units: 1
@@ -73,29 +75,14 @@ applications:
       - "8"
     options:
       enable_livestatus: true
-  thruk-agent:
-    charm: cs:thruk-agent
-    num_units: 0
-    series: bionic
-  nrpe:
-    charm: cs:nrpe
+  openstack-service-checks:
+    charm: cs:openstack-service-checks
+    num_units: 1
     options:
-      swap: ''
-  nova-cloud-controller:
-    charm: cs:nova-cloud-controller
-    num_units: 1
+      check-neutron-agents: False
+      check-octavia: False
     to:
-      - "9"
-  cinder:
-    charm: cs:cinder
-    num_units: 1
-    to:
-      - "10"
-  rabbitmq-server:
-    charm: cs:rabbitmq-server
-    num_units: 1
-    to:
-      - "11"
+      - "12"
   prometheus:
     charm: cs:prometheus2
     num_units: 1
@@ -111,49 +98,48 @@ applications:
     num_units: 1
     to:
       - "13"
-  prometheus-openstack-exporter:
-    charm: cs:prometheus-openstack-exporter
+  elastic:
+    charm: cs:elasticsearch
     num_units: 1
     options:
-      snap_channel: stable
-    to:
-      - "0"
-  openstack-service-checks:
-    charm: cs:openstack-service-checks
+      es-heap-size: 1
+  filebeat:
+    charm: cs:filebeat
+  grafana:
+    charm: cs:grafana
     num_units: 1
     options:
-      check-neutron-agents: False
-      check-octavia: False
-    to:
-      - "12"
+      install_method: snap
+      snap_channel: 21.04/stable
+  hw-health:
+    charm: cs:hw-health
+  keystone:
+    charm: cs:keystone
+    num_units: 1
+  mongo:
+    charm: cs:mongodb
+    num_units: 1
+  thruk-agent:
+    charm: cs:thruk-agent
+    num_units: 0
+    series: bionic
+  nrpe:
+    charm: cs:nrpe
+    options:
+      swap: ''
+  nova-cloud-controller:
+    charm: cs:nova-cloud-controller
+    num_units: 1
+  cinder:
+    charm: cs:cinder
+    num_units: 1
+  rabbitmq-server:
+    charm: cs:rabbitmq-server
+    num_units: 1
   sysconfig:
     charm: cs:sysconfig
   telegraf:
     charm: cs:telegraf-41
-  nova-compute:
-    charm: cs:nova-compute
-    num_units: 1
-    to:
-      - "2"
-  glance:
-    charm: cs:glance
-    num_units: 1
-    to:
-      - "3"
-  neutron-api:
-    charm: cs:neutron-api
-    num_units: 1
-    to:
-      - "1"
-    options:
-      manage-neutron-plugin-legacy-mode: True
-      flat-network-providers: physnet1
-      neutron-security-groups: true
-  placement:
-    charm: cs:placement
-    num_units: 1
-    to:
-      - "0"
   neutron-openvswitch:
     charm: cs:neutron-openvswitch
     num_units: 0
@@ -170,19 +156,12 @@ machines:
   "3": {}
   "4":
     mem: 3G
-  "5": {}
-  "6": {}
   "7":
     series: bionic
   "8":
     series: bionic
-  "9": {}
-  "10": {}
-  "11": {}
   "12": {}
   "13": {}
-  "14": {}
-  "15": {}
 relations:
 - - prometheus-openstack-exporter:nrpe-external-master
   - nrpe:nrpe-external-master

--- a/tests/bundles/focal-stable.yaml
+++ b/tests/bundles/focal-stable.yaml
@@ -98,6 +98,12 @@ applications:
     num_units: 1
     to:
       - "8"
+  canonical-livepatch:
+    charm: cs:canonical-livepatch
+    num_units: 0
+  cinder:
+    charm: cs:cinder
+    num_units: 1
   elastic:
     charm: cs:elasticsearch
     num_units: 1
@@ -119,10 +125,9 @@ applications:
   mongo:
     charm: cs:mongodb
     num_units: 1
-  thruk-agent:
-    charm: cs:thruk-agent
+  neutron-openvswitch:
+    charm: cs:neutron-openvswitch
     num_units: 0
-    series: bionic
   nrpe:
     charm: cs:nrpe
     options:
@@ -130,9 +135,9 @@ applications:
   nova-cloud-controller:
     charm: cs:nova-cloud-controller
     num_units: 1
-  cinder:
-    charm: cs:cinder
-    num_units: 1
+  prometheus-libvirt-exporter:
+    charm: cs:prometheus-libvirt-exporter
+    num_units: 0
   rabbitmq-server:
     charm: cs:rabbitmq-server
     num_units: 1
@@ -140,15 +145,10 @@ applications:
     charm: cs:sysconfig
   telegraf:
     charm: cs:telegraf-41
-  neutron-openvswitch:
-    charm: cs:neutron-openvswitch
+  thruk-agent:
+    charm: cs:thruk-agent
     num_units: 0
-  prometheus-libvirt-exporter:
-    charm: cs:prometheus-libvirt-exporter
-    num_units: 0
-  canonical-livepatch:
-    charm: cs:canonical-livepatch
-    num_units: 0
+    series: bionic
 machines:
   "0": {}
   "1": {}

--- a/tests/bundles/overlays/bionic-train-candidate.yaml.j2
+++ b/tests/bundles/overlays/bionic-train-candidate.yaml.j2
@@ -21,6 +21,13 @@ applications:
   neutron-api:
     options:
       openstack-origin: cloud:bionic-train
+  placement:
+    charm: cs:placement
+    num_units: 1
+    to:
+      - "0"
+    options:
+      openstack-origin: cloud:bionic-train
   elasticsearch:
     channel: candidate
   grafana:
@@ -51,3 +58,10 @@ applications:
     channel: candidate
   prometheus-libvirt-exporter:
     channel: candidate
+relations:
+- - placement:shared-db
+  - mysql:shared-db
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement

--- a/tests/bundles/overlays/bionic-train-stable.yaml.j2
+++ b/tests/bundles/overlays/bionic-train-stable.yaml.j2
@@ -21,3 +21,17 @@ applications:
   neutron-api:
     options:
       openstack-origin: cloud:bionic-train
+  placement:
+    charm: cs:placement
+    num_units: 1
+    to:
+      - "0"
+    options:
+      openstack-origin: cloud:bionic-train
+relations:
+- - placement:shared-db
+  - mysql:shared-db
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement

--- a/tests/bundles/overlays/bionic-ussuri-candidate.yaml.j2
+++ b/tests/bundles/overlays/bionic-ussuri-candidate.yaml.j2
@@ -23,6 +23,10 @@ applications:
     options:
       openstack-origin: cloud:bionic-ussuri
   placement:
+    charm: cs:placement
+    num_units: 1
+    to:
+      - "0"
     options:
       openstack-origin: cloud:bionic-ussuri
   elasticsearch:
@@ -55,3 +59,10 @@ applications:
     channel: candidate
   prometheus-libvirt-exporter:
     channel: candidate
+relations:
+- - placement:shared-db
+  - mysql:shared-db
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement

--- a/tests/bundles/overlays/bionic-ussuri-stable.yaml.j2
+++ b/tests/bundles/overlays/bionic-ussuri-stable.yaml.j2
@@ -23,5 +23,16 @@ applications:
     options:
       openstack-origin: cloud:bionic-ussuri
   placement:
+    charm: cs:placement
+    num_units: 1
+    to:
+      - "0"
     options:
       openstack-origin: cloud:bionic-ussuri
+relations:
+- - placement:shared-db
+  - mysql:shared-db
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement

--- a/tests/bundles/xenial-stable.yaml
+++ b/tests/bundles/xenial-stable.yaml
@@ -92,6 +92,14 @@ applications:
     num_units: 1
     to:
       - "8"
+  canonical-livepatch:
+    charm: cs:canonical-livepatch
+    num_units: 0
+  cinder:
+    charm: cs:cinder
+    num_units: 1
+    options:
+      openstack-origin: cloud:xenial-queens
   elastic:
     charm: cs:elasticsearch
     num_units: 1
@@ -113,8 +121,8 @@ applications:
   mongo:
     charm: cs:mongodb
     num_units: 1
-  thruk-agent:
-    charm: cs:thruk-agent
+  neutron-openvswitch:
+    charm: cs:neutron-openvswitch
     num_units: 0
   nrpe:
     charm: cs:nrpe
@@ -125,11 +133,9 @@ applications:
     num_units: 1
     options:
       openstack-origin: cloud:xenial-queens
-  cinder:
-    charm: cs:cinder
-    num_units: 1
-    options:
-      openstack-origin: cloud:xenial-queens
+  prometheus-libvirt-exporter:
+    charm: cs:prometheus-libvirt-exporter
+    num_units: 0
   rabbitmq-server:
     charm: cs:rabbitmq-server
     num_units: 1
@@ -137,14 +143,8 @@ applications:
     charm: cs:sysconfig
   telegraf:
     charm: cs:telegraf-41
-  neutron-openvswitch:
-    charm: cs:neutron-openvswitch
-    num_units: 0
-  prometheus-libvirt-exporter:
-    charm: cs:prometheus-libvirt-exporter
-    num_units: 0
-  canonical-livepatch:
-    charm: cs:canonical-livepatch
+  thruk-agent:
+    charm: cs:thruk-agent
     num_units: 0
 machines:
   "0": {}

--- a/tests/bundles/xenial-stable.yaml
+++ b/tests/bundles/xenial-stable.yaml
@@ -20,6 +20,11 @@ applications:
       - "1"
       - "2"
       - "3"
+  easyrsa:
+    charm: cs:~containers/easyrsa
+    num_units: 1
+    to:
+      - "1"
   elastic:
     charm: cs:elasticsearch
     num_units: 1
@@ -68,6 +73,9 @@ applications:
       - "8"
     options:
       enable_livestatus: true
+  thruk-agent:
+    charm: cs:thruk-agent
+    num_units: 0
   nrpe:
     charm: cs:nrpe
     options:
@@ -113,6 +121,7 @@ applications:
       snap_channel: stable
     to:
       - "0"
+  # openstack-service-checks is not available on xenial; skipping
   sysconfig:
     charm: cs:sysconfig
   telegraf:
@@ -138,21 +147,27 @@ applications:
     num_units: 1
     to:
       - "1"
+    options:
+      manage-neutron-plugin-legacy-mode: True
+      flat-network-providers: physnet1
+      neutron-security-groups: true
+  # Skipping placement; placement not compatible with xenial/queens
+  neutron-openvswitch:
+    charm: cs:neutron-openvswitch
+    num_units: 0
   prometheus-libvirt-exporter:
     charm: cs:prometheus-libvirt-exporter
     num_units: 0
   canonical-livepatch:
     charm: cs:canonical-livepatch
     num_units: 0
-  thruk-agent:
-    charm: cs:thruk-agent
-    num_units: 0
 machines:
   "0": {}
   "1": {}
   "2": {}
   "3": {}
-  "4": {}
+  "4":
+    mem: 3G
   "5": {}
   "6": {}
   "7": {} 
@@ -193,8 +208,11 @@ relations:
   - mongo:database
 - - graylog:elasticsearch
   - elastic:client
+- - easyrsa:client
+  - graylog:certificates
 - - sysconfig:juju-info
   - mysql:juju-info
+# Skipping openstack-service-check relations; requires bionic or newer
 - - prometheus-ceph-exporter:nrpe-external-master
   - nrpe:nrpe-external-master
 - - prometheus-ceph-exporter:ceph-exporter
@@ -212,6 +230,7 @@ relations:
 - - ceph-mon:nrpe-external-master
   - nrpe:nrpe-external-master
 - ["ceph-osd", "filebeat"]
+# Skipping openstack-service-check relations; requires bionic or newer
 - - nova-cloud-controller:shared-db
   - mysql:shared-db
 - - nova-cloud-controller:shared-db-cell
@@ -258,6 +277,13 @@ relations:
   - glance:image-service
 - - grafana:dashboards
   - telegraf:dashboards
+- - neutron-openvswitch:neutron-plugin-api
+  - neutron-api:neutron-plugin-api
+- - nova-compute:neutron-plugin
+  - neutron-openvswitch:neutron-plugin
+- - neutron-openvswitch:amqp
+  - rabbitmq-server:amqp
+# Skipping placement relations; placement not compatible with xenial/queens
 - - nova-compute:juju-info
   - prometheus-libvirt-exporter:juju-info
 - - prometheus:target

--- a/tests/bundles/xenial-stable.yaml
+++ b/tests/bundles/xenial-stable.yaml
@@ -8,6 +8,14 @@ applications:
       source: cloud:xenial-queens
     to:
       - "0"
+  # Skipping placement; placement not compatible with xenial/queens
+  prometheus-openstack-exporter:
+    charm: cs:prometheus-openstack-exporter
+    num_units: 1
+    options:
+      snap_channel: stable
+    to:
+      - "0"
   ceph-osd:
     charm: cs:ceph-osd
     num_units: 3
@@ -25,23 +33,30 @@ applications:
     num_units: 1
     to:
       - "1"
-  elastic:
-    charm: cs:elasticsearch
-    num_units: 1
-    options:
-      es-heap-size: 1
-    to:
-      - "15"
-  filebeat:
-    charm: cs:filebeat
-  grafana:
-    charm: cs:grafana
+  neutron-api:
+    charm: cs:neutron-api
     num_units: 1
     to:
-      - "5"
+      - "1"
     options:
-      install_method: snap
-      snap_channel: 21.04/stable
+      openstack-origin: cloud:xenial-queens
+      manage-neutron-plugin-legacy-mode: True
+      flat-network-providers: physnet1
+      neutron-security-groups: true
+  nova-compute:
+    charm: cs:nova-compute
+    options:
+      openstack-origin: cloud:xenial-queens
+    num_units: 1
+    to:
+      - "2"
+  glance:
+    charm: cs:glance
+    num_units: 1
+    options:
+      openstack-origin: cloud:xenial-queens
+    to:
+      - "3"
   graylog:
     charm: cs:graylog
     num_units: 1
@@ -49,18 +64,6 @@ applications:
       channel: 2/stable
     to:
       - "4"
-  hw-health:
-    charm: cs:hw-health
-  keystone:
-    charm: cs:keystone
-    num_units: 1
-    to:
-      - "6"
-  mongo:
-    charm: cs:mongodb
-    num_units: 1
-    to:
-      - "14"
   mysql:
     charm: cs:percona-cluster
     num_units: 1
@@ -73,32 +76,7 @@ applications:
       - "8"
     options:
       enable_livestatus: true
-  thruk-agent:
-    charm: cs:thruk-agent
-    num_units: 0
-  nrpe:
-    charm: cs:nrpe
-    options:
-      swap: ''
-  nova-cloud-controller:
-    charm: cs:nova-cloud-controller
-    num_units: 1
-    to:
-      - "9"
-    options:
-      openstack-origin: cloud:xenial-queens
-  cinder:
-    charm: cs:cinder
-    num_units: 1
-    options:
-      openstack-origin: cloud:xenial-queens
-    to:
-      - "10"
-  rabbitmq-server:
-    charm: cs:rabbitmq-server
-    num_units: 1
-    to:
-      - "11"
+  # Skipping openstack-service-checks; not available on xenial
   prometheus:
     charm: cs:prometheus2
     num_units: 1
@@ -114,44 +92,51 @@ applications:
     num_units: 1
     to:
       - "13"
-  prometheus-openstack-exporter:
-    charm: cs:prometheus-openstack-exporter
+  elastic:
+    charm: cs:elasticsearch
     num_units: 1
     options:
-      snap_channel: stable
-    to:
-      - "0"
-  # openstack-service-checks is not available on xenial; skipping
+      es-heap-size: 1
+  filebeat:
+    charm: cs:filebeat
+  grafana:
+    charm: cs:grafana
+    num_units: 1
+    options:
+      install_method: snap
+      snap_channel: 21.04/stable
+  hw-health:
+    charm: cs:hw-health
+  keystone:
+    charm: cs:keystone
+    num_units: 1
+  mongo:
+    charm: cs:mongodb
+    num_units: 1
+  thruk-agent:
+    charm: cs:thruk-agent
+    num_units: 0
+  nrpe:
+    charm: cs:nrpe
+    options:
+      swap: ''
+  nova-cloud-controller:
+    charm: cs:nova-cloud-controller
+    num_units: 1
+    options:
+      openstack-origin: cloud:xenial-queens
+  cinder:
+    charm: cs:cinder
+    num_units: 1
+    options:
+      openstack-origin: cloud:xenial-queens
+  rabbitmq-server:
+    charm: cs:rabbitmq-server
+    num_units: 1
   sysconfig:
     charm: cs:sysconfig
   telegraf:
     charm: cs:telegraf-41
-  nova-compute:
-    charm: cs:nova-compute
-    options:
-      openstack-origin: cloud:xenial-queens
-    num_units: 1
-    to:
-      - "2"
-  glance:
-    charm: cs:glance
-    num_units: 1
-    options:
-      openstack-origin: cloud:xenial-queens
-    to:
-      - "3"
-  neutron-api:
-    charm: cs:neutron-api
-    options:
-      openstack-origin: cloud:xenial-queens
-    num_units: 1
-    to:
-      - "1"
-    options:
-      manage-neutron-plugin-legacy-mode: True
-      flat-network-providers: physnet1
-      neutron-security-groups: true
-  # Skipping placement; placement not compatible with xenial/queens
   neutron-openvswitch:
     charm: cs:neutron-openvswitch
     num_units: 0
@@ -168,17 +153,10 @@ machines:
   "3": {}
   "4":
     mem: 3G
-  "5": {}
-  "6": {}
-  "7": {} 
+  "7": {}
   "8": {}
-  "9": {}
-  "10": {}
-  "11": {}
   "12": {}
   "13": {}
-  "14": {}
-  "15": {}
 relations:
 - - prometheus-openstack-exporter:nrpe-external-master
   - nrpe:nrpe-external-master

--- a/tests/bundles/xenial-stable.yaml
+++ b/tests/bundles/xenial-stable.yaml
@@ -68,12 +68,12 @@ applications:
     charm: cs:percona-cluster
     num_units: 1
     to:
-      - "7"
+      - "5"
   nagios:
     charm: cs:nagios
     num_units: 1
     to:
-      - "8"
+      - "6"
     options:
       enable_livestatus: true
   # Skipping openstack-service-checks; not available on xenial
@@ -81,17 +81,17 @@ applications:
     charm: cs:prometheus2
     num_units: 1
     to:
-      - "12"
+      - "7"
   prometheus-alertmanager:
     charm: cs:prometheus-alertmanager
     num_units: 1
     to:
-      - "13"
+      - "8"
   prometheus-ceph-exporter:
     charm: cs:prometheus-ceph-exporter
     num_units: 1
     to:
-      - "13"
+      - "8"
   elastic:
     charm: cs:elasticsearch
     num_units: 1
@@ -153,10 +153,10 @@ machines:
   "3": {}
   "4":
     mem: 3G
+  "5": {}
+  "6": {}
   "7": {}
   "8": {}
-  "12": {}
-  "13": {}
 relations:
 - - prometheus-openstack-exporter:nrpe-external-master
   - nrpe:nrpe-external-master


### PR DESCRIPTION
Organizational/consistency improvements across bundles/overlays

Performed a number of updates to organize and improve consistency
across the xenial/bionic/focal bundles, as well as a few overlay
improvements.  This could probably be minimized and reduced to "just
the bugs/misses", but this is what I would suggest.

These changes make it easier to do a ```diff
{xenial,bionic}-stable.yaml``` or similar command to determine deltas
between the 3 base bundle files.

* Added easyrsa to xenial and focal bundles
* Added thruk-agent to focal bundle with series set to bionic.
* Added neutron-openvswitch and related neutron-api options to xenial
  and bionic bundles.
* Copied Graylog-related memory constraint to the xenial/bionic
  bundles as well.
* Added comments about apps which are skipped in particular bundles to
  make the reasons for such clear.  (e.g. o-s-c, placement)
* Made other minor changes to make diffing between xenial/bionic and
  bionic/focal cleaner.
* Updated bionic overlays for placement service
* Apps landed on the same machines are now listed near each other,
  to make it easier to understand where apps are landed at a glance.
* Machine number references removed for all machines with single apps
  and no special constraints.  Exceptions made for machines which have
  special constraints in at least one of the 3 stable bundles.
* Re-numbered machines to eliminate gaps.
* Re-ordered apps without explicit machine assignments.