### PR TITLE
Suggested changes rework

### DIFF
--- a/tests/bundles/bionic-stable.yaml
+++ b/tests/bundles/bionic-stable.yaml
@@ -55,12 +55,12 @@ applications:
     charm: cs:percona-cluster
     num_units: 1
     to:
-      - "7"
+      - "5"
   nagios:
     charm: cs:nagios
     num_units: 1
     to:
-      - "8"
+      - "6"
     options:
       enable_livestatus: true
   thruk-agent:
@@ -83,17 +83,17 @@ applications:
     charm: cs:prometheus2
     num_units: 1
     to:
-      - "12"
+      - "7"
   prometheus-alertmanager:
     charm: cs:prometheus-alertmanager
     num_units: 1
     to:
-      - "13"
+      - "8"
   prometheus-ceph-exporter:
     charm: cs:prometheus-ceph-exporter
     num_units: 1
     to:
-      - "13"
+      - "8"
   prometheus-openstack-exporter:
     charm: cs:prometheus-openstack-exporter
     num_units: 1
@@ -108,7 +108,7 @@ applications:
       check-neutron-agents: False
       check-octavia: False
     to:
-      - "12"
+      - "7"
   sysconfig:
     charm: cs:sysconfig
   telegraf:
@@ -149,10 +149,10 @@ machines:
   "3": {}
   "4":
     mem: 3G
+  "5": {}
+  "6": {}
   "7": {}
   "8": {}
-  "12": {}
-  "13": {}
 relations:
 - - prometheus-openstack-exporter:nrpe-external-master
   - nrpe:nrpe-external-master

--- a/tests/bundles/bionic-stable.yaml
+++ b/tests/bundles/bionic-stable.yaml
@@ -28,15 +28,11 @@ applications:
     num_units: 1
     options:
       es-heap-size: 1
-    to:
-      - "15"
   filebeat:
     charm: cs:filebeat
   grafana:
     charm: cs:grafana
     num_units: 1
-    to:
-      - "5"
     options:
       install_method: snap
       snap_channel: 21.04/stable
@@ -52,13 +48,9 @@ applications:
   keystone:
     charm: cs:keystone
     num_units: 1
-    to:
-      - "6"
   mongo:
     charm: cs:mongodb
     num_units: 1
-    to:
-      - "14"
   mysql:
     charm: cs:percona-cluster
     num_units: 1
@@ -81,18 +73,12 @@ applications:
   nova-cloud-controller:
     charm: cs:nova-cloud-controller
     num_units: 1
-    to:
-      - "9"
   cinder:
     charm: cs:cinder
     num_units: 1
-    to:
-      - "10"
   rabbitmq-server:
     charm: cs:rabbitmq-server
     num_units: 1
-    to:
-      - "11"
   prometheus:
     charm: cs:prometheus2
     num_units: 1
@@ -163,17 +149,10 @@ machines:
   "3": {}
   "4":
     mem: 3G
-  "5": {}
-  "6": {}
-  "7": {} 
+  "7": {}
   "8": {}
-  "9": {}
-  "10": {}
-  "11": {}
   "12": {}
   "13": {}
-  "14": {}
-  "15": {}
 relations:
 - - prometheus-openstack-exporter:nrpe-external-master
   - nrpe:nrpe-external-master

--- a/tests/bundles/bionic-stable.yaml
+++ b/tests/bundles/bionic-stable.yaml
@@ -67,10 +67,10 @@ applications:
   nagios:
     charm: cs:nagios
     num_units: 1
-    options:
-      enable_livestatus: true
     to:
       - "8"
+    options:
+      enable_livestatus: true
   thruk-agent:
     charm: cs:thruk-agent
     num_units: 0
@@ -142,6 +142,14 @@ applications:
     num_units: 1
     to:
       - "1"
+    options:
+      manage-neutron-plugin-legacy-mode: True
+      flat-network-providers: physnet1
+      neutron-security-groups: true
+  # Skipping placement; placement not compatible with bionic/stein
+  neutron-openvswitch:
+    charm: cs:neutron-openvswitch
+    num_units: 0
   prometheus-libvirt-exporter:
     charm: cs:prometheus-libvirt-exporter
     num_units: 0
@@ -153,7 +161,8 @@ machines:
   "1": {}
   "2": {}
   "3": {}
-  "4": {}
+  "4":
+    mem: 3G
   "5": {}
   "6": {}
   "7": {} 
@@ -267,6 +276,13 @@ relations:
   - glance:image-service
 - - grafana:dashboards
   - telegraf:dashboards
+- - neutron-openvswitch:neutron-plugin-api
+  - neutron-api:neutron-plugin-api
+- - nova-compute:neutron-plugin
+  - neutron-openvswitch:neutron-plugin
+- - neutron-openvswitch:amqp
+  - rabbitmq-server:amqp
+# Skipping placement relations; placement not compatible with xenial/queens
 - - nova-compute:juju-info
   - prometheus-libvirt-exporter:juju-info
 - - prometheus:target
@@ -279,4 +295,3 @@ relations:
   - nrpe:nrpe-external-master
 - - graylog:nrpe-external-master
   - nrpe:nrpe-external-master
-

--- a/tests/bundles/focal-stable.yaml
+++ b/tests/bundles/focal-stable.yaml
@@ -18,6 +18,11 @@ applications:
       - "1"
       - "2"
       - "3"
+  easyrsa:
+    charm: cs:~containers/easyrsa
+    num_units: 1
+    to:
+      - "1"
   elastic:
     charm: cs:elasticsearch
     num_units: 1
@@ -68,6 +73,10 @@ applications:
       - "8"
     options:
       enable_livestatus: true
+  thruk-agent:
+    charm: cs:thruk-agent
+    num_units: 0
+    series: bionic
   nrpe:
     charm: cs:nrpe
     options:
@@ -203,6 +212,8 @@ relations:
   - mongo:database
 - - graylog:elasticsearch
   - elastic:client
+- - easyrsa:client
+  - graylog:certificates
 - - sysconfig:juju-info
   - mysql:juju-info
 - - openstack-service-checks:juju-info
@@ -292,8 +303,9 @@ relations:
   - prometheus-libvirt-exporter:scrape
 - - canonical-livepatch:juju-info
   - ceph-osd:juju-info
+- - thruk-agent:general-info
+  - nagios:juju-info
 - - grafana:nrpe-external-master
   - nrpe:nrpe-external-master
 - - graylog:nrpe-external-master
   - nrpe:nrpe-external-master
-

--- a/tests/bundles/focal-stable.yaml
+++ b/tests/bundles/focal-stable.yaml
@@ -28,15 +28,11 @@ applications:
     num_units: 1
     options:
       es-heap-size: 1
-    to:
-      - "15"
   filebeat:
     charm: cs:filebeat
   grafana:
     charm: cs:grafana
     num_units: 1
-    to:
-      - "5"
     options:
       install_method: snap
       snap_channel: 21.04/stable
@@ -52,13 +48,9 @@ applications:
   keystone:
     charm: cs:keystone
     num_units: 1
-    to:
-      - "6"
   mongo:
     charm: cs:mongodb
     num_units: 1
-    to:
-      - "14"
   mysql:
     charm: cs:percona-cluster
     num_units: 1
@@ -84,18 +76,12 @@ applications:
   nova-cloud-controller:
     charm: cs:nova-cloud-controller
     num_units: 1
-    to:
-      - "9"
   cinder:
     charm: cs:cinder
     num_units: 1
-    to:
-      - "10"
   rabbitmq-server:
     charm: cs:rabbitmq-server
     num_units: 1
-    to:
-      - "11"
   prometheus:
     charm: cs:prometheus2
     num_units: 1
@@ -170,19 +156,12 @@ machines:
   "3": {}
   "4":
     mem: 3G
-  "5": {}
-  "6": {}
   "7":
     series: bionic
   "8":
     series: bionic
-  "9": {}
-  "10": {}
-  "11": {}
   "12": {}
   "13": {}
-  "14": {}
-  "15": {}
 relations:
 - - prometheus-openstack-exporter:nrpe-external-master
   - nrpe:nrpe-external-master

--- a/tests/bundles/focal-stable.yaml
+++ b/tests/bundles/focal-stable.yaml
@@ -56,13 +56,13 @@ applications:
     num_units: 1
     series: bionic
     to:
-      - "7"
+      - "5"
   nagios:
     charm: cs:nagios
     num_units: 1
     series: bionic
     to:
-      - "8"
+      - "6"
     options:
       enable_livestatus: true
   thruk-agent:
@@ -86,17 +86,17 @@ applications:
     charm: cs:prometheus2
     num_units: 1
     to:
-      - "12"
+      - "7"
   prometheus-alertmanager:
     charm: cs:prometheus-alertmanager
     num_units: 1
     to:
-      - "13"
+      - "8"
   prometheus-ceph-exporter:
     charm: cs:prometheus-ceph-exporter
     num_units: 1
     to:
-      - "13"
+      - "8"
   prometheus-openstack-exporter:
     charm: cs:prometheus-openstack-exporter
     num_units: 1
@@ -111,7 +111,7 @@ applications:
       check-neutron-agents: False
       check-octavia: False
     to:
-      - "12"
+      - "7"
   sysconfig:
     charm: cs:sysconfig
   telegraf:
@@ -156,12 +156,12 @@ machines:
   "3": {}
   "4":
     mem: 3G
-  "7":
+  "5":
     series: bionic
-  "8":
+  "6":
     series: bionic
-  "12": {}
-  "13": {}
+  "7": {}
+  "8": {}
 relations:
 - - prometheus-openstack-exporter:nrpe-external-master
   - nrpe:nrpe-external-master

--- a/tests/bundles/overlays/bionic-train-candidate.yaml.j2
+++ b/tests/bundles/overlays/bionic-train-candidate.yaml.j2
@@ -21,6 +21,13 @@ applications:
   neutron-api:
     options:
       openstack-origin: cloud:bionic-train
+  placement:
+    charm: cs:placement
+    num_units: 1
+    to:
+      - "0"
+    options:
+      openstack-origin: cloud:bionic-train
   elasticsearch:
     channel: candidate
   grafana:
@@ -51,3 +58,10 @@ applications:
     channel: candidate
   prometheus-libvirt-exporter:
     channel: candidate
+relations:
+- - placement:shared-db
+  - mysql:shared-db
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement

--- a/tests/bundles/overlays/bionic-train-stable.yaml.j2
+++ b/tests/bundles/overlays/bionic-train-stable.yaml.j2
@@ -21,3 +21,17 @@ applications:
   neutron-api:
     options:
       openstack-origin: cloud:bionic-train
+  placement:
+    charm: cs:placement
+    num_units: 1
+    to:
+      - "0"
+    options:
+      openstack-origin: cloud:bionic-train
+relations:
+- - placement:shared-db
+  - mysql:shared-db
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement

--- a/tests/bundles/overlays/bionic-ussuri-candidate.yaml.j2
+++ b/tests/bundles/overlays/bionic-ussuri-candidate.yaml.j2
@@ -23,6 +23,10 @@ applications:
     options:
       openstack-origin: cloud:bionic-ussuri
   placement:
+    charm: cs:placement
+    num_units: 1
+    to:
+      - "0"
     options:
       openstack-origin: cloud:bionic-ussuri
   elasticsearch:
@@ -55,3 +59,10 @@ applications:
     channel: candidate
   prometheus-libvirt-exporter:
     channel: candidate
+relations:
+- - placement:shared-db
+  - mysql:shared-db
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement

--- a/tests/bundles/overlays/bionic-ussuri-stable.yaml.j2
+++ b/tests/bundles/overlays/bionic-ussuri-stable.yaml.j2
@@ -23,5 +23,16 @@ applications:
     options:
       openstack-origin: cloud:bionic-ussuri
   placement:
+    charm: cs:placement
+    num_units: 1
+    to:
+      - "0"
     options:
       openstack-origin: cloud:bionic-ussuri
+relations:
+- - placement:shared-db
+  - mysql:shared-db
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement

--- a/tests/bundles/xenial-stable.yaml
+++ b/tests/bundles/xenial-stable.yaml
@@ -57,12 +57,12 @@ applications:
     charm: cs:percona-cluster
     num_units: 1
     to:
-      - "7"
+      - "5"
   nagios:
     charm: cs:nagios
     num_units: 1
     to:
-      - "8"
+      - "6"
     options:
       enable_livestatus: true
   thruk-agent:
@@ -89,17 +89,17 @@ applications:
     charm: cs:prometheus2
     num_units: 1
     to:
-      - "12"
+      - "7"
   prometheus-alertmanager:
     charm: cs:prometheus-alertmanager
     num_units: 1
     to:
-      - "13"
+      - "8"
   prometheus-ceph-exporter:
     charm: cs:prometheus-ceph-exporter
     num_units: 1
     to:
-      - "13"
+      - "8"
   prometheus-openstack-exporter:
     charm: cs:prometheus-openstack-exporter
     num_units: 1
@@ -153,10 +153,10 @@ machines:
   "3": {}
   "4":
     mem: 3G
+  "5": {}
+  "6": {}
   "7": {}
   "8": {}
-  "12": {}
-  "13": {}
 relations:
 - - prometheus-openstack-exporter:nrpe-external-master
   - nrpe:nrpe-external-master

--- a/tests/bundles/xenial-stable.yaml
+++ b/tests/bundles/xenial-stable.yaml
@@ -30,15 +30,11 @@ applications:
     num_units: 1
     options:
       es-heap-size: 1
-    to:
-      - "15"
   filebeat:
     charm: cs:filebeat
   grafana:
     charm: cs:grafana
     num_units: 1
-    to:
-      - "5"
     options:
       install_method: snap
       snap_channel: 21.04/stable
@@ -54,13 +50,9 @@ applications:
   keystone:
     charm: cs:keystone
     num_units: 1
-    to:
-      - "6"
   mongo:
     charm: cs:mongodb
     num_units: 1
-    to:
-      - "14"
   mysql:
     charm: cs:percona-cluster
     num_units: 1
@@ -83,8 +75,6 @@ applications:
   nova-cloud-controller:
     charm: cs:nova-cloud-controller
     num_units: 1
-    to:
-      - "9"
     options:
       openstack-origin: cloud:xenial-queens
   cinder:
@@ -92,13 +82,9 @@ applications:
     num_units: 1
     options:
       openstack-origin: cloud:xenial-queens
-    to:
-      - "10"
   rabbitmq-server:
     charm: cs:rabbitmq-server
     num_units: 1
-    to:
-      - "11"
   prometheus:
     charm: cs:prometheus2
     num_units: 1
@@ -121,7 +107,7 @@ applications:
       snap_channel: stable
     to:
       - "0"
-  # openstack-service-checks is not available on xenial; skipping
+  # Skipping openstack-service-checks; not available on xenial
   sysconfig:
     charm: cs:sysconfig
   telegraf:
@@ -142,12 +128,11 @@ applications:
       - "3"
   neutron-api:
     charm: cs:neutron-api
-    options:
-      openstack-origin: cloud:xenial-queens
     num_units: 1
     to:
       - "1"
     options:
+      openstack-origin: cloud:xenial-queens
       manage-neutron-plugin-legacy-mode: True
       flat-network-providers: physnet1
       neutron-security-groups: true
@@ -168,17 +153,10 @@ machines:
   "3": {}
   "4":
     mem: 3G
-  "5": {}
-  "6": {}
-  "7": {} 
+  "7": {}
   "8": {}
-  "9": {}
-  "10": {}
-  "11": {}
   "12": {}
   "13": {}
-  "14": {}
-  "15": {}
 relations:
 - - prometheus-openstack-exporter:nrpe-external-master
   - nrpe:nrpe-external-master

--- a/tests/bundles/xenial-stable.yaml
+++ b/tests/bundles/xenial-stable.yaml
@@ -20,6 +20,11 @@ applications:
       - "1"
       - "2"
       - "3"
+  easyrsa:
+    charm: cs:~containers/easyrsa
+    num_units: 1
+    to:
+      - "1"
   elastic:
     charm: cs:elasticsearch
     num_units: 1
@@ -68,6 +73,9 @@ applications:
       - "8"
     options:
       enable_livestatus: true
+  thruk-agent:
+    charm: cs:thruk-agent
+    num_units: 0
   nrpe:
     charm: cs:nrpe
     options:
@@ -113,6 +121,7 @@ applications:
       snap_channel: stable
     to:
       - "0"
+  # openstack-service-checks is not available on xenial; skipping
   sysconfig:
     charm: cs:sysconfig
   telegraf:
@@ -138,21 +147,27 @@ applications:
     num_units: 1
     to:
       - "1"
+    options:
+      manage-neutron-plugin-legacy-mode: True
+      flat-network-providers: physnet1
+      neutron-security-groups: true
+  # Skipping placement; placement not compatible with xenial/queens
+  neutron-openvswitch:
+    charm: cs:neutron-openvswitch
+    num_units: 0
   prometheus-libvirt-exporter:
     charm: cs:prometheus-libvirt-exporter
     num_units: 0
   canonical-livepatch:
     charm: cs:canonical-livepatch
     num_units: 0
-  thruk-agent:
-    charm: cs:thruk-agent
-    num_units: 0
 machines:
   "0": {}
   "1": {}
   "2": {}
   "3": {}
-  "4": {}
+  "4":
+    mem: 3G
   "5": {}
   "6": {}
   "7": {} 
@@ -193,8 +208,11 @@ relations:
   - mongo:database
 - - graylog:elasticsearch
   - elastic:client
+- - easyrsa:client
+  - graylog:certificates
 - - sysconfig:juju-info
   - mysql:juju-info
+# Skipping openstack-service-check relations; requires bionic or newer
 - - prometheus-ceph-exporter:nrpe-external-master
   - nrpe:nrpe-external-master
 - - prometheus-ceph-exporter:ceph-exporter
@@ -212,6 +230,7 @@ relations:
 - - ceph-mon:nrpe-external-master
   - nrpe:nrpe-external-master
 - ["ceph-osd", "filebeat"]
+# Skipping openstack-service-check relations; requires bionic or newer
 - - nova-cloud-controller:shared-db
   - mysql:shared-db
 - - nova-cloud-controller:shared-db-cell
@@ -258,6 +277,13 @@ relations:
   - glance:image-service
 - - grafana:dashboards
   - telegraf:dashboards
+- - neutron-openvswitch:neutron-plugin-api
+  - neutron-api:neutron-plugin-api
+- - nova-compute:neutron-plugin
+  - neutron-openvswitch:neutron-plugin
+- - neutron-openvswitch:amqp
+  - rabbitmq-server:amqp
+# Skipping placement relations; placement not compatible with xenial/queens
 - - nova-compute:juju-info
   - prometheus-libvirt-exporter:juju-info
 - - prometheus:target


### PR DESCRIPTION
Organizational/consistency improvements across bundles/overlays

Performed a number of updates to organize and improve consistency
across the xenial/bionic/focal bundles, as well as a few overlay
improvements.  This could probably be minimized and reduced to "just
the bugs/misses", but this is what I would suggest.

These changes make it easier to do a ```diff
{xenial,bionic}-stable.yaml``` or similar command to determine deltas
between the 3 base bundle files.

* Added easyrsa to xenial and focal bundles
* Added thruk-agent to focal bundle with series set to bionic.
* Added neutron-openvswitch and related neutron-api options to xenial
  and bionic bundles.
* Copied Graylog-related memory constraint to the xenial/bionic
  bundles as well.
* Added comments about apps which are skipped in particular bundles to
  make the reasons for such clear.  (e.g. o-s-c, placement)
* Made other minor changes to make diffing between xenial/bionic and
  bionic/focal cleaner.
* Updated bionic overlays for placement service
* Machine number references removed for all machines with single apps
  and no special constraints.  Exceptions made for machines which have
  special constraints in at least one of the 3 stable bundles.
* Re-numbered machines to eliminate gaps.
